### PR TITLE
refactor(android): move implementation inside module

### DIFF
--- a/android/src/main/java/com/ismaestro/IsMaestroModule.kt
+++ b/android/src/main/java/com/ismaestro/IsMaestroModule.kt
@@ -1,11 +1,21 @@
 package com.ismaestro
 
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactMethod
 import java.net.InetAddress
 import java.net.Socket
 
-class IsMaestroModule internal constructor(context: ReactApplicationContext): IsMaestroSpec(context) {
-    fun isMaestro(ipAddress: String, port: Int): Boolean {
+class IsMaestroModule internal constructor(context: ReactApplicationContext) : IsMaestroSpec(context) {
+    override fun getName(): String {
+        return NAME;
+    }
+
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    override fun isMaestro(): Boolean {
+        return determineIsMaestro("localhost", 7001)
+    }
+
+    private fun determineIsMaestro(ipAddress: String, port: Int): Boolean {
         return try {
             val socket = Socket(InetAddress.getByName(ipAddress), port)
             socket.close()

--- a/android/src/newarch/IsMaestroSpec.kt
+++ b/android/src/newarch/IsMaestroSpec.kt
@@ -2,16 +2,5 @@ package com.ismaestro
 
 import com.facebook.react.bridge.ReactApplicationContext
 
-open class IsMaestroSpec internal constructor(context: ReactApplicationContext) : NativeIsMaestroSpec(context) {
-    private val module: IsMaestroModule by lazy {
-        IsMaestroModule(context)
-    }
-
-    override fun getName(): String {
-        return IsMaestroModule.NAME;
-    }
-
-    override fun isMaestro(): Boolean {
-        return module.isMaestro("localhost", 7001)
-    }
+abstract class IsMaestroSpec internal constructor(context: ReactApplicationContext) : NativeIsMaestroSpec(context) {
 }

--- a/android/src/oldarch/IsMaestroSpec.kt
+++ b/android/src/oldarch/IsMaestroSpec.kt
@@ -2,20 +2,9 @@ package com.ismaestro
 
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
-import com.facebook.react.bridge.ReactMethod
-import com.facebook.react.bridge.ReactModuleWithSpec
 
-abstract class IsMaestroSpec internal constructor(context: ReactApplicationContext) : ReactContextBaseJavaModule(context), ReactModuleWithSpec {
-    private val module: IsMaestroModule by lazy {
-        IsMaestroModule(context)
-    }
+abstract class IsMaestroSpec internal constructor(context: ReactApplicationContext) :
+    ReactContextBaseJavaModule(context) {
 
-    override fun getName(): String {
-        return IsMaestroModule.NAME;
-    }
-
-    @ReactMethod(isBlockingSynchronousMethod = true)
-    fun isMaestro(): Boolean {
-        return IsMaestroModule(this.reactApplicationContext).isMaestro("localhost", 7001)
-    }
+    abstract fun isMaestro(): Boolean
 }


### PR DESCRIPTION
## Summary

Spec files on Android contained some of the implementation details. These files should only include abstract interfaces for the module. I've moved them inside the module.
This also removes the code duplication between the old architecture and the new architecture