### PR TITLE
fix: change port number to adapt new version

### DIFF
--- a/ios/IsMaestro.mm
+++ b/ios/IsMaestro.mm
@@ -63,7 +63,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isMaestro)
 {
-    BOOL isReachable = [self isUrlReachable:@"http://localhost" port:9080];
+    BOOL isReachable = [self isUrlReachable:@"http://localhost" port:22087];
     
     return @(isReachable);
 }


### PR DESCRIPTION
# Context

With the next release of maestro, the communication port is going to change to 22087. 9080 was a very common port for communication for many other services and we had various reports of maestro not installing driver properly for iOS flows. For context you can have a look at this issue:

https://github.com/mobile-dev-inc/maestro/issues/646

# Proposed Change
For compatibility with the future release of maestro, changing the port number in the library to 22087. We can merge this as soon as the CLI is released and you can release this change in your library as well. Marking this pull request as a draft until the CLI is released.

PS: I don't see this changing frequently but for fixing the issue around the port already being used permanently we will eventually be looking for a free port on the maestro side. Long term solution is definitely going to be detecting this through env. variable or something else (we are still discussing the best solution internally).

But this library is going to be useful for all react native users 🙌 Thanks for contribution.

# Testing

https://user-images.githubusercontent.com/12881364/217206434-d743a6a2-0c7e-4f90-887d-13fd2c555357.mp4


