### PR TITLE
Unlock nodejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,9 +79,6 @@
     "react": "*",
     "react-native": "*"
   },
-  "engines": {
-    "node": ">= 16.0.0"
-  },
   "packageManager": "^yarn@1.22.15",
   "jest": {
     "preset": "react-native",


### PR DESCRIPTION
to fix issue:
```
The engine "node" is incompatible with this module. Expected version ">= 16.0.0". Got "14.21.2"
error Found incompatible module.
```