### PR TITLE
fix: change port to work with maestro >= 1.37.0

### DIFF
--- a/ios/IsMaestro.mm
+++ b/ios/IsMaestro.mm
@@ -31,7 +31,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isMaestro)
 {
-    bool isReachable = [self isUrlReachable:@"http://localhost" port:22087];
+    bool isReachable = [self isUrlReachable:@"http://localhost" port:7001];
     
     return @(isReachable);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-is-maestro",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "Detect synchronously if the app is currently running in an E2E test environment with maestro",
   "scripts": {
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
Fixes #16 but will break on Maestro v1.36.0 and earlier.

This is a breaking change. Maestro 1.36.0 and before uses port 22087 by default. Maestro version 1.37.0 and beyond use 7001

For details see:
- https://github.com/jpudysz/react-native-is-maestro/issues/16
- https://github.com/mobile-dev-inc/maestro/issues/1816

As I explained in #16, I'm not sure if this change is worth making. Not only does it break support for Maestro v1.36.0 - I also have doubts it will work on maestro cloud due to the change made in https://github.com/mobile-dev-inc/maestro/pull/1732 to add sharding / parallel execution. I'm also not sure the change to port 7001 was intended by the maestro maintainers. It seemed like a side-effect of the change to add sharding. I would not be surprised if they changed it back.

I'm opening it in case it is helpful for the maintainers of this package or other people stuck on this problem. However, it seems that a more robust solution for this package to work will require a larger change that checks multiple ports as [explained here](https://github.com/mobile-dev-inc/maestro/issues/1816#issuecomment-2402533232).

I appreciate @jpudysz for making this library and wanted to show my thanks by offering this contribution. Ultimately, I will defer to @jpudysz to make the judgement call on whether this PR should be merged or if a different approach should be taken instead.